### PR TITLE
Adds texlive-fontsextra to Archlinux's Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Depending on your GNU/Linux distribution the package names may be different. Bas
 
 __On Arch Linux:__
 
-    $ sudo pacman -Sy texlive-core texlive-latexextra
+    $ sudo pacman -Sy texlive-core texlive-latexextra texlive-fontsextra
 
 __On Fedora:__
 


### PR DESCRIPTION
I get the following error if the package is not installed when I try to
build the PDF using "make":

    LaTeX Error: File `fontawesome.sty' not found.

Tested using the archlinux/base:latest Docker image. Commands ran before
building the PDF are:

    pacman -Sy texlive-core texlive-latexextra make

Then try build the PDF using:

    make clean
    make

After I get the error above I installed texlive-fontsextra using:

    pacman -Sy texlive-fontsextra

Then tried to build again. The build worked OK the second time. The
generated PDF also had the right fontawesome icons.

Before installing texlive-fontsextra, I tried installing the fontawesome
package using:

    pacman -Sy ttf-font-awesome

I got the same error when I tried to build after though.