### PR TITLE
Fixes "prerequisites" Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To clean up all generated and intermediate content, type:
 
     $ make clean
 
-## Pre-requistes for building
+## Prerequisites for building
 Depending on your GNU/Linux distribution the package names may be different. Basically, you need the `texlive` package, as well as whichever "extras" package contains the moderncv stuff.
 
 __On Arch Linux:__


### PR DESCRIPTION
Seems prerequisites in the main README file has a typo. This PR
fixes that.